### PR TITLE
Add support for callbacks to DEL and EXPIRE

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,12 @@ set(key, value, callback)
 
   * **expire**
 ```javascript
-expire(key, value)
+expire(key, value, callback)
+```
+
+  * **del**
+```javascript
+del(key, callback)
 ```
 
   * **hget**

--- a/src/redis-connection-pool.js
+++ b/src/redis-connection-pool.js
@@ -164,7 +164,7 @@ RedisConnectionPool.prototype.serverInfo = function (cb) {
  *
  */
 RedisConnectionPool.prototype.expire = function (key, data, cb) {
-  redisSingle.apply(this, ['expire', key, data]);
+  redisSingle.apply(this, ['expire', key, data, cb]);
 };
 
 /**
@@ -209,7 +209,7 @@ RedisConnectionPool.prototype.get = function (key, cb) {
  *
  */
 RedisConnectionPool.prototype.del = function (key, cb) {
-  redisSingle.apply(this, ['del', key]);
+  redisSingle.apply(this, ['del', key, cb]);
 };
 
 /**
@@ -375,6 +375,9 @@ RedisConnectionPool.prototype.check = function () {
 
 function redisSingle (funcName, key, val, cb) {
   var pool = this.pool;
+  if (typeof val === 'function') {
+    cb = val;
+  }
   pool.acquire(function (err, client) {
     if (val) {
       client[funcName](key, val, function (err, reply) {

--- a/src/redis-connection-pool.js
+++ b/src/redis-connection-pool.js
@@ -163,7 +163,7 @@ RedisConnectionPool.prototype.serverInfo = function (cb) {
  *   value - (number) - TTL in seconds
  *
  */
-RedisConnectionPool.prototype.expire = function (key, data) {
+RedisConnectionPool.prototype.expire = function (key, data, cb) {
   redisSingle.apply(this, ['expire', key, data]);
 };
 
@@ -208,7 +208,7 @@ RedisConnectionPool.prototype.get = function (key, cb) {
  *   key  - (string) - The key of the value you wish to delete
  *
  */
-RedisConnectionPool.prototype.del = function (key) {
+RedisConnectionPool.prototype.del = function (key, cb) {
   redisSingle.apply(this, ['del', key]);
 };
 
@@ -373,16 +373,22 @@ RedisConnectionPool.prototype.check = function () {
 
 
 
-function redisSingle (funcName, key, val) {
+function redisSingle (funcName, key, val, cb) {
   var pool = this.pool;
   pool.acquire(function (err, client) {
     if (val) {
-      client[funcName](key, val, function () {
+      client[funcName](key, val, function (err, reply) {
         pool.release(client);
+        if (typeof cb === 'function') {
+          cb(err, reply);
+        }
       });
     } else {
-      client[funcName](key, function () {
+      client[funcName](key, function (err, reply) {
         pool.release(client);
+        if (typeof cb === 'function') {
+          cb(err, reply);
+        }
       });
     }
   });


### PR DESCRIPTION
Simple patch to both allow for some kind of callback and also return the values that would normally be returned from such calls. DEL returns the number of items deleted and EXPIRE returns a success or failure. 