### PR TITLE
adding redis send_command api

### DIFF
--- a/src/redis-connection-pool.js
+++ b/src/redis-connection-pool.js
@@ -370,8 +370,23 @@ RedisConnectionPool.prototype.check = function () {
   return redisCheck.apply(this, []);
 };
 
+/**
+ * Function: send_command
+ *
+ * Sends an explicit command to the redis server. Helpful for new commands in redis
+ *   that aren't supported yet by this JS API.
+ *
+ * Parameters:
+ *
+ *   command_name  - (string) - The redis command to execute
+ *   args          - (array) - The arguments to the redis command 
+ *   cb            - (function) - Callback to be executed on completion
+ *
+ */
 
-
+RedisConnectionPool.prototype.send_command = function (command_name, args, cb) {
+  redisSingle.apply(this, ['send_command', command_name, args, cb]);
+};
 
 function redisSingle (funcName, key, val, cb) {
   var pool = this.pool;


### PR DESCRIPTION
This function is in the npm redis module, and is pretty helpful for the odd redis commands that the API doesn't otherwise support.