### PR TITLE
Fixed redisCheck to work with mocks not returning proper version string

### DIFF
--- a/src/redis-connection-pool.js
+++ b/src/redis-connection-pool.js
@@ -619,9 +619,10 @@ function redisCheck() {
       q.reject(err);
     });
     client.on('ready', function () {
+      client.server_info = client.server_info || {};
       self.version_string = client.server_info.redis_version;
       self.version_array = client.server_info.versions;
-      if (self.version_array[0] < 2) {
+      if (!self.version_array || self.version_array[0] < 2) {
         self.blocking_support = false;
       }
       client.quit();


### PR DESCRIPTION
Fixed redisCheck function to behave properly when no version string is supported by Redis or a Redis mock.